### PR TITLE
Catch duplicate query name in request

### DIFF
--- a/libddog/common/errors.py
+++ b/libddog/common/errors.py
@@ -1,2 +1,6 @@
 class UnresolvedFormulaIdentifiers(Exception):
     pass
+
+
+class RequestQueryNamesNotUnique(Exception):
+    pass

--- a/tests_unit/dashboards/test_formula.py
+++ b/tests_unit/dashboards/test_formula.py
@@ -41,17 +41,11 @@ def test_formula__unresolved_identifier() -> None:
     q1 = query.identifier()
     q2 = Identifier("q2")  # we just made it up
 
-    request = Request(
-        formulas=[
-            Formula(
-                formula=q1 * q2,
-            )
-        ],
-        queries=[query],
-    )
-
     with pytest.raises(UnresolvedFormulaIdentifiers) as ctx:
-        request.as_dict()
+        Request(
+            formulas=[Formula(formula=q1 * q2)],
+            queries=[query],
+        )
 
     assert ctx.value.args[0] == (
         "identifier(s) 'q2' in the formula '(q1 * q2)' not present in any query"

--- a/tests_unit/dashboards/test_request.py
+++ b/tests_unit/dashboards/test_request.py
@@ -1,3 +1,6 @@
+import pytest
+
+from libddog.common.errors import RequestQueryNamesNotUnique
 from libddog.dashboards import (
     Comparator,
     ConditionalFormat,
@@ -123,3 +126,24 @@ def test_request__synthesize_formulas_from_queries() -> None:
             "palette": "dog_classic",
         },
     }
+
+
+def test_request__non_distinct_query_names() -> None:
+    request = Request(
+        queries=[
+            # both the metric name and the query name should vary on the loop
+            # variable in some way, but here the query name is just a constant
+            Query(f"svc.req.timing.{percentile}", name="p95")
+            .filter("$cluster")
+            .agg("avg")
+            .rollup("avg")
+            for percentile in ["95percentile", "median"]
+        ],
+    )
+
+    with pytest.raises(RequestQueryNamesNotUnique) as ctx:
+        request.as_dict()
+
+    assert ctx.value.args[0] == (
+        "not all query names in request are distinct: 'p95', 'p95'"
+    )

--- a/tests_unit/dashboards/test_request.py
+++ b/tests_unit/dashboards/test_request.py
@@ -129,20 +129,18 @@ def test_request__synthesize_formulas_from_queries() -> None:
 
 
 def test_request__non_distinct_query_names() -> None:
-    request = Request(
-        queries=[
-            # both the metric name and the query name should vary on the loop
-            # variable in some way, but here the query name is just a constant
-            Query(f"svc.req.timing.{percentile}", name="p95")
-            .filter("$cluster")
-            .agg("avg")
-            .rollup("avg")
-            for percentile in ["95percentile", "median"]
-        ],
-    )
-
     with pytest.raises(RequestQueryNamesNotUnique) as ctx:
-        request.as_dict()
+        Request(
+            queries=[
+                # both the metric name and the query name should vary on the loop
+                # variable in some way, but here the query name is just a constant
+                Query(f"svc.req.timing.{percentile}", name="p95")
+                .filter("$cluster")
+                .agg("avg")
+                .rollup("avg")
+                for percentile in ["95percentile", "median"]
+            ],
+        )
 
     assert ctx.value.args[0] == (
         "not all query names in request are distinct: 'p95', 'p95'"


### PR DESCRIPTION
## Fixes the following issues

Fixes #45 

## Description

* `Request.__init__` now validates that all query names are distinct.
* It now also validates the formulas where previously it would do this when `as_dict()` was called.