### PR TITLE
Support horizontal layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.1.5 (next)
 
-- ...
+- Added HLayout and HLayoutStack to allow managed laying out of widgets
+  horizontally.
 
 ## 0.1.4
 

--- a/libddog/dashboards/__init__.py
+++ b/libddog/dashboards/__init__.py
@@ -38,6 +38,7 @@ from libddog.dashboards.enums import (
     TitleAlign,
     VerticalAlign,
 )
+from libddog.dashboards.layouts import HLayout, HLayoutStack
 from libddog.dashboards.presets import NotePreset
 from libddog.dashboards.widgets import (
     Group,
@@ -58,6 +59,8 @@ __all__ = (
     "Formula",
     "FormulaLimit",
     "Group",
+    "HLayout",
+    "HLayoutStack",
     "LayoutType",
     "LegendColumn",
     "LegendLayout",

--- a/libddog/dashboards/exceptions.py
+++ b/libddog/dashboards/exceptions.py
@@ -1,0 +1,2 @@
+class HLayoutError(Exception):
+    pass

--- a/libddog/dashboards/layouts.py
+++ b/libddog/dashboards/layouts.py
@@ -7,6 +7,16 @@ from libddog.dashboards.widgets import Note, Widget
 
 
 class HLayout:
+    """
+    A horizontal layout of equal sized widgets that always fills the whole row,
+    up to the page width. If the widgets passed in do not fill the row then
+    padding is inserted in the form of a transparent Note which has the
+    appearance of empty space.
+
+    Calling `get_widgets` modifies the `size` and `position` of the widgets
+    contained in the layout before returning them.
+    """
+
     page_width = 12
 
     def __init__(self, width: int, height: int, widgets: List[Widget]) -> None:
@@ -47,6 +57,14 @@ class HLayout:
 
 
 class HLayoutStack:
+    """
+    A vertical layout of `HLayout` rows, which allows stacking `HLayout`s vertically.
+
+    Calling `get_widgets` modifies the `size` and `position` of the widgets
+    contained in the inner `HLayout`s before returning them as one flat list of
+    widgets.
+    """
+
     def __init__(self, layouts: List[HLayout]) -> None:
         self.layouts = layouts
 

--- a/libddog/dashboards/layouts.py
+++ b/libddog/dashboards/layouts.py
@@ -31,7 +31,10 @@ class HLayout:
         for widget in self.widgets:
             overflow = (cum_width + self.width) - self.page_width
             if overflow > 0:
-                raise HLayoutError("Overflowed page width by %r units" % overflow)
+                raise HLayoutError(
+                    "Overflowed page width (%r) by %r units"
+                    % (self.page_width, overflow)
+                )
 
             widget.size.width = self.width
             widget.size.height = self.height

--- a/libddog/dashboards/layouts.py
+++ b/libddog/dashboards/layouts.py
@@ -1,0 +1,71 @@
+from typing import List
+
+from libddog.dashboards.components import Position, Size
+from libddog.dashboards.exceptions import HLayoutError
+from libddog.dashboards.presets import NotePreset
+from libddog.dashboards.widgets import Note, Widget
+
+
+class HLayout:
+    page_width = 12
+
+    def __init__(self, width: int, height: int, widgets: List[Widget]) -> None:
+        self.width = width
+        self.height = height
+        self.widgets = widgets
+
+    def _lay_out_widgets(self) -> None:
+        cum_width = 0
+        y_pos = 0
+
+        for widget in self.widgets:
+            overflow = (cum_width + self.width) - self.page_width
+            if overflow > 0:
+                raise HLayoutError("Overflowed page width by %r units" % overflow)
+
+            widget.size.width = self.width
+            widget.size.height = self.height
+
+            widget.position.x = cum_width
+            widget.position.y = y_pos
+
+            cum_width += widget.size.width
+
+        delta_width = abs(self.page_width - cum_width)
+        if delta_width > 0:
+            note = Note(
+                preset=NotePreset.CAPTION,
+                content="",
+                size=Size(width=delta_width, height=self.height),
+                position=Position(x=cum_width, y=y_pos),
+            )
+            self.widgets.append(note)
+
+    def get_widgets(self) -> List[Widget]:
+        self._lay_out_widgets()
+        return self.widgets
+
+
+class HLayoutStack:
+    def __init__(self, layouts: List[HLayout]) -> None:
+        self.layouts = layouts
+
+    def _lay_out_widgets(self) -> None:
+        for layout in self.layouts:
+            layout._lay_out_widgets()
+
+        cum_height = 0
+        for layout in self.layouts:
+            for widget in layout.widgets:
+                widget.position.y = cum_height
+
+            cum_height += layout.height
+
+    def get_widgets(self) -> List[Widget]:
+        self._lay_out_widgets()
+
+        widgets = []
+        for layout in self.layouts:
+            widgets.extend(layout.widgets)
+
+        return widgets

--- a/libddog/dashboards/widgets.py
+++ b/libddog/dashboards/widgets.py
@@ -28,11 +28,20 @@ from libddog.metrics.query import QueryState
 
 
 class Widget:
-    _allowed_atts: Dict[Any, Sequence[str]] = {}
-
     """
     A visual component on a dashboard.
     """
+
+    _allowed_atts: Dict[Any, Sequence[str]] = {}
+
+    def __init__(
+        self,
+        *,
+        size: Optional[Size] = None,
+        position: Optional[Position] = None,
+    ) -> None:
+        self.size = Size.backfill(self, size)
+        self.position = position or Position()
 
     def as_dict(self) -> JsonDict:
         raise NotImplementedError
@@ -112,6 +121,8 @@ class Note(Widget):
         size: Optional[Size] = None,
         position: Optional[Position] = None,
     ) -> None:
+        super().__init__(size=size, position=position)
+
         self.preset = preset
         self.content = content
         self.background_color = background_color
@@ -121,8 +132,6 @@ class Note(Widget):
         self.show_tick = show_tick
         self.tick_edge = tick_edge
         self.has_padding = has_padding
-        self.size = Size.backfill(self, size)
-        self.position = position or Position()
 
     def apply_preset(self) -> "Note":
         """
@@ -221,6 +230,8 @@ class QueryValue(Widget):
         size: Optional[Size] = None,
         position: Optional[Position] = None,
     ) -> None:
+        super().__init__(size=size, position=position)
+
         self.title = title
         self.title_size = title_size
         self.title_align = title_align
@@ -229,8 +240,6 @@ class QueryValue(Widget):
         self.custom_unit = custom_unit
         self.precision = precision
         self.requests = requests
-        self.size = Size.backfill(self, size)
-        self.position = position or Position()
 
     def request_as_dict(self, request: Request) -> Dict[str, Any]:
         dct = super().request_as_dict(request)
@@ -290,6 +299,8 @@ class Timeseries(Widget):
         size: Optional[Size] = None,
         position: Optional[Position] = None,
     ) -> None:
+        super().__init__(size=size, position=position)
+
         self.title = title
         self.title_size = title_size
         self.title_align = title_align
@@ -305,8 +316,6 @@ class Timeseries(Widget):
         self.requests = requests
         self.yaxis = yaxis or YAxis()
         self.markers = markers or []
-        self.size = Size.backfill(self, size)
-        self.position = position or Position()
 
     def request_as_dict(self, request: Request) -> JsonDict:
         dct = super().request_as_dict(request)
@@ -363,13 +372,13 @@ class Toplist(Widget):
         size: Optional[Size] = None,
         position: Optional[Position] = None,
     ) -> None:
+        super().__init__(size=size, position=position)
+
         self.title = title
         self.title_size = title_size
         self.title_align = title_align
         self.time = time or Time(live_span=LiveSpan.GLOBAL_TIME)
         self.requests = requests
-        self.size = Size.backfill(self, size)
-        self.position = position or Position()
 
     def request_as_dict(self, request: Request) -> JsonDict:
         dct = super().request_as_dict(request)
@@ -405,12 +414,12 @@ class Group(Widget):
         size: Optional[Size] = None,
         position: Optional[Position] = None,
     ) -> None:
+        super().__init__(size=size, position=position)
+
         self.title = title
         self.layout_type = layout_type
         self.background_color = background_color
         self.widgets = widgets or []
-        self.size = Size.backfill(self, size)
-        self.position = position or Position()
 
     def as_dict(self) -> JsonDict:
         dct = {

--- a/libtests/managers.py
+++ b/libtests/managers.py
@@ -33,8 +33,7 @@ class QADashboardManager:
                 existing_id = dash["id"]
                 return existing_id
 
-        # TODO: else create a new dash so we can use that id
-        raise NotImplementedError
+        return self.manager.create_dashboard(dashboard=dashboard)
 
     def update_live_dashboard(self, dashboard: Dashboard, id: str) -> None:
         if self.rx_string_template.search(dashboard.desc):

--- a/testdata/config/dashboards.py
+++ b/testdata/config/dashboards.py
@@ -1,12 +1,13 @@
 from typing import List
 
-from dashboards import qa_metrics, qa_minimal, qa_widgets
+from dashboards import qa_layouts, qa_metrics, qa_minimal, qa_widgets
 
 from libddog.dashboards import Dashboard
 
 
 def get_dashboards() -> List[Dashboard]:
     dashes = [
+        qa_layouts.get_dashboard(),
         qa_metrics.get_dashboard(),
         qa_minimal.get_dashboard(),
         qa_widgets.get_dashboard(),

--- a/testdata/dashboards/qa_layouts.py
+++ b/testdata/dashboards/qa_layouts.py
@@ -1,0 +1,59 @@
+from dashboards.shared import get_dashboard_desc_template, get_region_tmpl_var_presets
+
+from libddog.dashboards import BackgroundColor, Dashboard, Group, Note, Widget
+from libddog.dashboards.layouts import HLayout, HLayoutStack
+
+
+def get_note(id: str) -> Widget:
+    return Note(
+        content=f"this is the {id} note",
+        background_color=BackgroundColor.YELLOW,
+    )
+
+
+def get_group() -> Widget:
+    # first row
+    fst = get_note("first")
+    snd = get_note("second")
+    # second row
+    # third row
+    thd = get_note("third")
+    frth = get_note("fourth")
+    fith = get_note("fifth")
+    # fourth row
+    sth = get_note("sixth")
+    # fifth row
+
+    layout = HLayoutStack(
+        layouts=[
+            HLayout(width=2, height=3, widgets=[fst, snd]),
+            HLayout(width=5, height=1, widgets=[]),
+            HLayout(width=4, height=2, widgets=[thd, frth, fith]),
+            HLayout(width=9, height=5, widgets=[sth]),
+            HLayout(width=2, height=2, widgets=[]),
+        ]
+    )
+    widgets = layout.get_widgets()
+
+    # Exercises most of the configurations we can achieve with HLayout
+    group = Group(
+        title="Exercise HLayout and HLayoutStack",
+        background_color=BackgroundColor.VIVID_ORANGE,
+        widgets=widgets,
+    )
+
+    return group
+
+
+def get_dashboard() -> Dashboard:
+    group = get_group()
+
+    tmpl_presets_region = get_region_tmpl_var_presets()
+    dashboard = Dashboard(
+        title="libddog QA: exercise layouts",
+        desc=get_dashboard_desc_template(),
+        widgets=[group],
+        tmpl_var_presets=tmpl_presets_region,
+    )
+
+    return dashboard

--- a/tests_integ/test_widgets.py
+++ b/tests_integ/test_widgets.py
@@ -50,6 +50,22 @@ def test_put_and_get_widgets() -> None:
     assert obj_matcher(expected, PATCHES) == obj_matcher(actual, PATCHES)
 
 
+def test_put_and_get_layouts() -> None:
+    mgr = QADashboardManager()
+    dashboard = mgr.load_definition_by_title("libddog QA: exercise layouts")
+
+    dash_id = mgr.assign_id_to_dashboard(dashboard)
+
+    # put the dashboard
+    mgr.update_live_dashboard(dashboard, dash_id)
+
+    # now read it back and assert that it matches our model
+    expected = dashboard.as_dict()
+    actual = mgr.manager.get_dashboard(id=dash_id)
+
+    assert obj_matcher(expected, PATCHES) == obj_matcher(actual, PATCHES)
+
+
 def test_dashboard_lifecycle() -> None:
     mgr = QADashboardManager()
     dashboard = mgr.load_definition_by_title("libddog QA: exercise dashboard lifecycle")

--- a/tests_unit/dashboards/test_hlayout.py
+++ b/tests_unit/dashboards/test_hlayout.py
@@ -1,0 +1,135 @@
+import pytest
+
+from libddog.dashboards import HLayout, Note, NotePreset, Position, Size
+from libddog.dashboards.exceptions import HLayoutError
+
+
+def test_hlayout__overrides_size_and_position() -> None:
+    # create two notes with very random sizes and positions
+    fst = Note(
+        content="this is a note",
+        size=Size(width=5, height=7),
+        position=Position(x=3, y=9),
+    )
+    snd = Note(
+        content="this is another note",
+        size=Size(width=8, height=1),
+        position=Position(x=2, y=0),
+    )
+
+    layout = HLayout(width=3, height=1, widgets=[fst, snd])
+    wids = layout.get_widgets()
+
+    # the two widgets are the ones we gave it
+    assert fst is wids[0]
+    assert snd is wids[1]
+
+    # the sizes and positions have been overridden by the layout
+    assert fst.size.width == 3
+    assert fst.size.height == 1
+    assert fst.position.x == 0
+    assert fst.position.y == 0
+
+    assert snd.size.width == 3
+    assert snd.size.height == 1
+    assert snd.position.x == 3
+    assert snd.position.y == 0
+
+
+def test_hlayout__adds_padding() -> None:
+    # create two notes that are not wide enough to fill the page width
+    fst = Note(content="this is a note")
+    snd = Note(content="this is another note")
+
+    layout = HLayout(width=3, height=1, widgets=[fst, snd])
+    wids = layout.get_widgets()
+
+    # the first two widgets are the ones we gave it
+    assert fst is wids[0]
+    assert snd is wids[1]
+
+    assert fst.size.width == 3
+    assert fst.size.height == 1
+    assert fst.position.x == 0
+    assert fst.position.y == 0
+
+    assert snd.size.width == 3
+    assert snd.size.height == 1
+    assert snd.position.x == 3
+    assert snd.position.y == 0
+
+    # there is a third padding widget
+    assert len(wids) == 3
+    pad = wids[2]
+
+    # it's a Note that looks transparent
+    assert isinstance(pad, Note)
+    assert pad.preset is NotePreset.CAPTION
+    assert pad.content == ""
+
+    # it's on the same line and extends until the end of the page
+    assert pad.size.width == 6
+    assert pad.size.height == 1
+    assert pad.position.x == 6
+    assert pad.position.y == 0
+
+
+def test_hlayout__no_padding() -> None:
+    # create two notes that ARE wide enough to fill the page width
+    fst = Note(content="this is a note")
+    snd = Note(content="this is another note")
+
+    layout = HLayout(width=6, height=2, widgets=[fst, snd])
+    wids = layout.get_widgets()
+
+    # the only two widgets are the ones we gave it
+    assert len(wids) == 2
+    assert fst is wids[0]
+    assert snd is wids[1]
+
+    assert fst.size.width == 6
+    assert fst.size.height == 2
+    assert fst.position.x == 0
+    assert fst.position.y == 0
+
+    assert snd.size.width == 6
+    assert snd.size.height == 2
+    assert snd.position.x == 6
+    assert snd.position.y == 0
+
+
+# Corner cases
+
+
+def test_hlayout__empty() -> None:
+    # create a layout without any widgets
+    layout = HLayout(width=4, height=2, widgets=[])
+    wids = layout.get_widgets()
+
+    # we get a single padding widget that fills the page width
+    assert len(wids) == 1
+    pad = wids[0]
+
+    # it's a Note that looks transparent
+    assert isinstance(pad, Note)
+    assert pad.preset is NotePreset.CAPTION
+    assert pad.content == ""
+
+    # it extends until the end of the page
+    assert pad.size.width == 12
+    assert pad.size.height == 2
+    assert pad.position.x == 0
+    assert pad.position.y == 0
+
+
+def test_hlayout__overflows_page_width() -> None:
+    # create two notes that are wider than the page width
+    fst = Note(content="this is a note")
+    snd = Note(content="this is another note")
+
+    layout = HLayout(width=9, height=2, widgets=[fst, snd])
+
+    with pytest.raises(HLayoutError) as ctx:
+        layout.get_widgets()
+
+    assert ctx.value.args[0] == "Overflowed page width by 6 units"

--- a/tests_unit/dashboards/test_hlayout.py
+++ b/tests_unit/dashboards/test_hlayout.py
@@ -132,4 +132,4 @@ def test_hlayout__overflows_page_width() -> None:
     with pytest.raises(HLayoutError) as ctx:
         layout.get_widgets()
 
-    assert ctx.value.args[0] == "Overflowed page width by 6 units"
+    assert ctx.value.args[0] == "Overflowed page width (12) by 6 units"

--- a/tests_unit/dashboards/test_hlayoutstack.py
+++ b/tests_unit/dashboards/test_hlayoutstack.py
@@ -1,0 +1,126 @@
+from libddog.dashboards import HLayout, Note, NotePreset
+from libddog.dashboards.layouts import HLayoutStack
+
+
+def test_hlayoutstack__one_layer() -> None:
+    # two widgets in a single row
+    fst = Note(content="this is a note")
+    snd = Note(content="this is another note")
+
+    stack = HLayoutStack(layouts=[HLayout(width=3, height=1, widgets=[fst, snd])])
+    wids = stack.get_widgets()
+
+    # the first two widgets are the ones we gave it
+    assert fst is wids[0]
+    assert snd is wids[1]
+
+    assert fst.size.width == 3
+    assert fst.size.height == 1
+    assert fst.position.x == 0
+    assert fst.position.y == 0
+
+    assert snd.size.width == 3
+    assert snd.size.height == 1
+    assert snd.position.x == 3
+    assert snd.position.y == 0
+
+    # there is a third padding widget
+    assert len(wids) == 3
+    pad = wids[2]
+
+    # it's a Note that looks transparent
+    assert isinstance(pad, Note)
+    assert pad.preset is NotePreset.CAPTION
+    assert pad.content == ""
+
+    # it's on the same line and extends until the end of the page
+    assert pad.size.width == 6
+    assert pad.size.height == 1
+    assert pad.position.x == 6
+    assert pad.position.y == 0
+
+
+def test_hlayoutstack__three_layers() -> None:
+    # first row (has padding)
+    fst = Note(content="this is a note")
+    snd = Note(content="this is another note")
+    # second row (no padding)
+    thd = Note(content="this is a third note")
+    frth = Note(content="this is a fourth note")
+    fith = Note(content="this is a fifth note")
+    # third row (has padding)
+    sth = Note(content="this is a sixth note")
+
+    stack = HLayoutStack(
+        layouts=[
+            HLayout(width=5, height=3, widgets=[fst, snd]),
+            HLayout(width=4, height=2, widgets=[thd, frth, fith]),
+            HLayout(width=9, height=5, widgets=[sth]),
+        ]
+    )
+    wids = stack.get_widgets()
+
+    assert len(wids) == 8
+
+    # row 1
+    assert wids[0] is fst
+    assert wids[1] is snd
+    pad1 = wids[2]
+
+    # row 2
+    assert wids[3] is thd
+    assert wids[4] is frth
+    assert wids[5] is fith
+
+    # row 3
+    assert wids[6] is sth
+    pad3 = wids[7]
+
+    # row 1 detailed
+    assert fst.size.width == 5
+    assert fst.size.height == 3
+    assert fst.position.x == 0
+    assert fst.position.y == 0
+
+    assert snd.size.width == 5
+    assert snd.size.height == 3
+    assert snd.position.x == 5
+    assert snd.position.y == 0
+
+    assert isinstance(pad1, Note)
+    assert pad1.preset is NotePreset.CAPTION
+    assert pad1.content == ""
+    assert pad1.size.width == 2
+    assert pad1.size.height == 3
+    assert pad1.position.x == 10
+    assert pad1.position.y == 0
+
+    # row 2 detailed
+    assert thd.size.width == 4
+    assert thd.size.height == 2
+    assert thd.position.x == 0
+    assert thd.position.y == 3
+
+    assert frth.size.width == 4
+    assert frth.size.height == 2
+    assert frth.position.x == 4
+    assert frth.position.y == 3
+
+    assert fith.size.width == 4
+    assert fith.size.height == 2
+    assert fith.position.x == 8
+    assert fith.position.y == 3
+
+    # row 3 detailed
+    assert sth.size.width == 9
+    assert sth.size.height == 5
+    assert sth.position.x == 0
+    assert sth.position.y == 5
+
+    assert isinstance(pad3, Note)
+    assert pad3.preset is NotePreset.CAPTION
+    assert pad3.content == ""
+    assert pad3.size.width == 3
+    assert pad3.size.height == 5
+    assert pad3.position.x == 9
+    assert pad3.position.y == 5


### PR DESCRIPTION
Adds the new classes `HLayout` and `HLayoutStack` which enables creating widgets out of context and then laying them out separately, without having to deal with sizes and positions manually.

It works the same way as a horizontal layout manager would work in most gui toolkits:
- It fills the whole width of the page by sizing the widgets to the same size (and adds padding if there is any space left at the end).
- Makes sure the page width is not exceeded and raises an exception if it is.
- `HLayout`s can be stacked on successive rows.